### PR TITLE
exit protocol 

### DIFF
--- a/honeypot/data_files/plugins.txt
+++ b/honeypot/data_files/plugins.txt
@@ -1,5 +1,5 @@
 #root
-http_reader	80	1111
+http_reader		80	1111
 https_reader 	443 4443
 ssh_plugin 		22	8888
 telnet_reader	23  9000

--- a/honeypot/plugins/http_reader.py
+++ b/honeypot/plugins/http_reader.py
@@ -64,6 +64,7 @@ class server_plugin(threading.Thread):
             self.tear_down()
 
     def tear_down(self):
+        print 'HTTP '+str(self.port)+' closing' 
         self.server.socket.close()
         self.server.shutdown()
 

--- a/honeypot/plugins/https_reader.py
+++ b/honeypot/plugins/https_reader.py
@@ -69,6 +69,7 @@ class server_plugin(threading.Thread):
             self.tear_down()
 
     def tear_down(self):
+        print 'HTTPS '+str(self.port)+' closing' 
         self.server.socket.close()
         self.server.shutdown()
 

--- a/honeypot/plugins/ssh_plugin.py
+++ b/honeypot/plugins/ssh_plugin.py
@@ -87,6 +87,12 @@ class server_plugin(threading.Thread):
         except KeyboardInterrupt, IOError:
                 self.tear_down()
 
+    def tear_down(self):
+        self.lock.acquire()
+        print 'ssh '+str(self.port)+' closing'   
+        self.lock.release()     
+        self.s.close()
+
 class client_thread(paramiko.ServerInterface, threading.Thread):
 
     client = None
@@ -113,12 +119,6 @@ class client_thread(paramiko.ServerInterface, threading.Thread):
         client_thread.time = datetime.datetime.now().time()
         self.daemon = True
         self.start()
-
-    def tear_down(self):
-        self.lock.acquire()
-        print 'ssh closing'   
-        self.lock.release()     
-        self.s.close()
 
     def run(self):
         # sets up a socket and begins listening for connection requests

--- a/honeypot/plugins/telnet_reader.py
+++ b/honeypot/plugins/telnet_reader.py
@@ -86,7 +86,7 @@ class server_plugin(threading.Thread):
 
     def tear_down(self):
         self.lock.acquire()
-        print 'telnet closing'   
+        print 'telnet '+str(self.port)+' closing'  
         self.lock.release()     
         self.s.close()
 


### PR DESCRIPTION
added a feature to our exit via keyboard or error to hopefully catch our random issue with not being able to use ctrl c to exit after an error. This actually takes all the plugins and goes through and runs the tear_down() in each plugin. Brad and I discussed this in class.
